### PR TITLE
0.1.2

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,13 +110,15 @@ declare namespace NSP {
         /**
          * retrieve a result from hook function
          */
-        process<T>(type: "error", e: Error, context: T): string;
+        process(type: "error", e: Error, context: any): string;
 
-        process<T>(type: "directive", src: string, context: T): string;
+        process(type: "directive", src: string, context: any): string;
 
-        process<T>(type: "declaration", src: string, context: T): string;
+        process(type: "declaration", src: string, context: any): string;
 
-        process<T>(type: "scriptlet", src: string, context: T): string;
+        process(type: "scriptlet", src: string, context: any): string;
+
+        process<R>(type: string, ...args: any[]): R;
 
         /**
          * pickup the taglib function
@@ -150,13 +152,15 @@ declare namespace NSP {
         /**
          * register a hook function
          */
-        hook(type: "error", fn: <T>(e: Error, context?: T) => string | void): void;
+        hook(type: "error", fn: (e: Error, context?: any) => string | void): void;
 
-        hook(type: "directive", fn: <T>(src: string, context?: T) => string | void): void;
+        hook(type: "directive", fn: (src: string, context?: any) => string | void): void;
 
-        hook(type: "declaration", fn: <T>(src: string, context?: T) => string | void): void;
+        hook(type: "declaration", fn: (src: string, context?: any) => string | void): void;
 
-        hook(type: "scriptlet", fn: <T>(src: string, context?: T) => string | void): void;
+        hook(type: "scriptlet", fn: (src: string, context?: any) => string | void): void;
+
+        hook(type: string, fn: (...args: any[]) => any): void;
 
         /**
          * parse a JSP document

--- a/index.d.ts
+++ b/index.d.ts
@@ -110,14 +110,6 @@ declare namespace NSP {
         /**
          * retrieve a result from hook function
          */
-        process(type: "error", e: Error, context: any): string;
-
-        process(type: "directive", src: string, context: any): string;
-
-        process(type: "declaration", src: string, context: any): string;
-
-        process(type: "scriptlet", src: string, context: any): string;
-
         process<R>(type: string, ...args: any[]): R;
 
         /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nsp-server-pages",
   "description": "NSP JavaScript Server Pages for Node.js",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "@kawanet",
   "bugs": {
     "url": "https://github.com/kawanet/nsp-server-pages/issues"

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,7 +16,7 @@ class App implements NSP.App {
     fnMap = new Map<string, (...args: any[]) => any>();
     options: NSP.Options;
 
-    protected listeners = new Map<string, Function>;
+    protected hooks = new Map<string, (...args: any[]) => any>;
     protected jsLoader: JsLoader;
     protected jspLoader: JspLoader;
     protected fileLoader: FileLoader;
@@ -28,13 +28,13 @@ class App implements NSP.App {
         if (!options.storeKey) options.storeKey = "#nsp";
     }
 
-    hook(type: string, fn: any): void {
-        this.listeners.set(type, fn);
+    hook(type: string, fn: (...args: any[]) => any): void {
+        this.hooks.set(type, fn);
     }
 
-    process(type: string, arg: any): any {
-        const fn = this.listeners.get(type);
-        if (fn) return fn(arg);
+    process(type: string, ...args: any[]): any {
+        const fn = this.hooks.get(type);
+        if (fn) return fn.apply(null, args);
     }
 
     log(message: string): void {

--- a/src/catch.ts
+++ b/src/catch.ts
@@ -1,10 +1,6 @@
-import {toXML} from "to-xml";
-
 import type {NSP} from "../index.js"
 
 const isPromise = <T>(v: any): v is Promise<T> => v && (typeof v.catch === "function");
-
-const escapeError = (e: Error): string => toXML({"#": (e?.message || String(e))});
 
 interface TagData {
     error?: Error;
@@ -31,11 +27,14 @@ export const catchFn = <T>(app: NSP.App, fn: NSP.NodeFn<T>): NSP.NodeFn<T> => {
                 data.error = e;
             }
 
-            // call the error handler
-            const result = app.process("error", e, context);
-            if (result != null) return result as string;
+            // call the error hook
+            const result: string = app.process("error", e, context);
 
-            return `<!--\n[ERR] ${escapeError(e)}\n-->`;
+            // if the hook returns nothing, throw the error
+            if (result == null) throw e;
+
+            // if the hook returns a string, show it
+            return result;
         }
     }
 };

--- a/test/400.hook-error.ts
+++ b/test/400.hook-error.ts
@@ -1,18 +1,17 @@
 import {strict as assert} from "assert";
 import {createNSP, NSP} from "../index.js";
 
-const TITLE = "400.on-error.ts";
+const TITLE = "400.hook-error.ts";
 
 describe(TITLE, () => {
-    const logger = {log: (): void => null};
-
-    const nsp = createNSP({logger});
+    const nsp = createNSP();
 
     /**
      * This pass the error to the next handler when it's a SyntaxError but not other errors.
      */
-    nsp.hook("error", (e: Error): void => {
+    nsp.hook("error", (e: Error): string => {
         if (e instanceof SyntaxError) throw e;
+        return `[${e?.message}]`;
     });
 
     nsp.addTagLib({


### PR DESCRIPTION
- `hook(type: string, fn: (...args: any[]) => any): void;` added to allow any type of hooks registered